### PR TITLE
fix: change informationLayerIds to informationLayers

### DIFF
--- a/prisma/interfaces.ts
+++ b/prisma/interfaces.ts
@@ -68,6 +68,11 @@ export type GeoJSONAsset = {
   geoJson: JsonValue;
 };
 
+export type InformationLayer = {
+  id: string;
+  attributes: JsonValue;
+}
+
 export interface StoryStep {
   id: number;
   stepNumber: number;
@@ -86,7 +91,7 @@ export interface StoryStep {
   datasources?: Datasource[];
   wmsLayers?: wmsLayer[];
   ThreeDFiles?: ThreeDFiles[];
-  informationLayerIds?: string[];
+  informationLayers?: InformationLayer[];
   geoJsonAssets: GeoJSONAsset[];
 }
 

--- a/prisma/migrations/20260116093205_exchange_information_layer_ids_for_information_layers/migration.sql
+++ b/prisma/migrations/20260116093205_exchange_information_layer_ids_for_information_layers/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `informationLayerIds` on the `StoryStep` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "StoryStep" DROP COLUMN "informationLayerIds",
+ADD COLUMN     "informationLayers" JSONB NOT NULL DEFAULT '[]'::jsonb,
+ALTER COLUMN "mapSources" SET DEFAULT '[]'::jsonb,
+ALTER COLUMN "modelUrl" DROP DEFAULT,
+ALTER COLUMN "geoJsonAssets" SET DEFAULT '[]'::jsonb;

--- a/prisma/migrations/20260116093205_exchange_information_layer_ids_for_information_layers/migration.sql
+++ b/prisma/migrations/20260116093205_exchange_information_layer_ids_for_information_layers/migration.sql
@@ -6,7 +6,7 @@
 */
 -- AlterTable
 ALTER TABLE "StoryStep" DROP COLUMN "informationLayerIds",
-ADD COLUMN     "informationLayers" JSONB NOT NULL DEFAULT '[]'::jsonb,
+ADD COLUMN "informationLayers" JSONB NOT NULL DEFAULT '[]'::jsonb,
 ALTER COLUMN "mapSources" SET DEFAULT '[]'::jsonb,
 ALTER COLUMN "modelUrl" DROP DEFAULT,
 ALTER COLUMN "geoJsonAssets" SET DEFAULT '[]'::jsonb;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,7 +98,7 @@ model StoryStep {
   datasources       Datasource[]
   wmsLayers         wmsLayer[]
   ThreeDFiles       ThreeDFiles[]
-  informationLayerIds String[]
+  informationLayers Json      @db.JsonB @default(dbgenerated("'[]'::jsonb"))
   mapSources  Json      @db.JsonB @default(dbgenerated("'[]'::jsonb"))
   modelUrl          String?
   geoJsonAssets      Json      @db.JsonB @default(dbgenerated("'[]'::jsonb"))

--- a/requests.http
+++ b/requests.http
@@ -64,7 +64,7 @@ Authorization: Bearer {{user_token}}
                         "zoomLevel": 4,
                         "backgroundMapId": null
                     },
-                    "informationLayerIds": [],
+                    "informationLayers": [],
                     "mapSources": [],
                     "is3D": false,
                     "modelUrl": "",

--- a/routes/Story/story.routes.ts
+++ b/routes/Story/story.routes.ts
@@ -4,7 +4,7 @@ import authMiddleware, { optionalAuthMiddleware, isRequestFromAdmin } from "../.
 import asyncHandler from "../../handlers/asyncHandler";
 import { filesUpload } from "../../utils/minio";
 import { userOwnsStory, OwnedStory, PublishedStory } from "./DbFilters";
-import type { GeoJSONAsset } from "../../prisma/interfaces.ts";
+import type { GeoJSONAsset, InformationLayer } from "../../prisma/interfaces.ts";
 import { minioClient } from "../../utils/minio";
 
 const prismaClient = new PrismaClient();
@@ -339,7 +339,7 @@ storyRouter.post(
             zoomLevel: number;
             backgroundMapId: string;
           };
-          informationLayerIds?: string[];
+          informationLayers?: InformationLayer[];
           mapSources?: any[];
           geoJsonAssets?: GeoJSONAsset[];
         }>;
@@ -376,7 +376,7 @@ storyRouter.post(
                   is3D: step.is3D ?? false,
                   navigation3D: step.navigation3D ?? {},
                   modelUrl: step.modelUrl ?? "",
-                  informationLayerIds: (step.informationLayerIds ?? []).map(String),
+                  informationLayers: step.informationLayers ? step.informationLayers : [],
                   mapSources: Array.isArray(step.mapSources) ? step.mapSources : [],
                   geoJsonAssets: step.geoJsonAssets ? step.geoJsonAssets : [],
                 }))
@@ -473,7 +473,7 @@ storyRouter.get(
                 centerCoordinate: true,
                 zoomLevel: true,
                 backgroundMapId: true,
-                informationLayerIds: true,
+                informationLayers: true,
                 is3D: true,
                 navigation3D: true,
                 modelUrl: true,
@@ -524,7 +524,7 @@ storyRouter.put(
             zoomLevel: number;
             backgroundMapId: string | null;
           };
-          informationLayerIds?: string[];
+          informationLayers?: InformationLayer[];
           geoJsonAssets?: GeoJSONAsset[];
         }>;
       }>;
@@ -584,7 +584,7 @@ storyRouter.put(
               interactionAddons: [],
               is3D: false,
               navigation3D: {},
-              informationLayerIds: (s.informationLayerIds ?? []).map(String),
+              informationLayers: s.informationLayers ?? [],
               geoJsonAssets: s.geoJsonAssets ?? [],
             }
           });


### PR DESCRIPTION
This PR is required for [#55](https://github.com/citysciencelab/cut-dana-platform-addon/pull/55) in the addon.
The `informationLayerIds` column is changed to `informationLayers` in order to save additional information to these layers.
For the new types to be generated the command `bunx prisma generate` is needed.

Please review